### PR TITLE
Use luarocks-build-hooks module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,22 +1,22 @@
 name: test
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
 
 jobs:
   luacheck:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     steps:
     -
       name: Checkout
       uses: actions/checkout@v2
       with:
         submodules: 'true'
-    -
-      name: Setup Lua
-      uses: leafo/gh-actions-lua@v8.0.0
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4.0.0
     -
       name: Install Tools
       run: luarocks install luacheck
@@ -27,32 +27,33 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     strategy:
       matrix:
         lua-version:
-          - "5.1"
-          - "5.2"
-          - "5.3"
-          - "5.4"
+          - "5.1.:latest"
+          - "5.2.:latest"
+          - "5.3.:latest"
+          - "5.4.:latest"
+          - "lj-v2.1:latest"
 
     steps:
+    -
+      name: Switch Lua Version
+      run: |
+        lenv -g use ${{ matrix.lua-version }}
+        lua -v || true
     -
       name: Checkout
       uses: actions/checkout@v2
       with:
         submodules: 'true'
     -
-      name: Setup Lua ${{ matrix.lua-version }}
-      uses: leafo/gh-actions-lua@v8.0.0
-      with:
-        luaVersion: ${{ matrix.lua-version }}
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4.0.0
-    -
       name: Install Tools
       run: |
-        sudo apt-get install libpcre2-dev -y
+        apt-get update
+        apt-get install libpcre2-dev -y
         luarocks install dump
     -
       name: Install

--- a/rockspecs/pcre2-scm-1.rockspec
+++ b/rockspecs/pcre2-scm-1.rockspec
@@ -2,36 +2,49 @@ rockspec_format = "3.0"
 package = "pcre2"
 version = "scm-1"
 source = {
-    url = "git+https://github.com/mah0x211/lua-pcre2.git"
+    url = "git+https://github.com/mah0x211/lua-pcre2.git",
 }
 description = {
     summary = "PCRE2 bindings for lua",
     homepage = "https://github.com/mah0x211/lua-pcre2",
     license = "MIT/X11",
-    maintainer = "Masatoshi Fukunaga"
+    maintainer = "Masatoshi Fukunaga",
 }
 dependencies = {
     "lua >= 5.1",
 }
 external_dependencies = {
-    LIBPCRE2 = {
-        header = "pcre2.h",
-        library = "pcre2-8",
-    }
+    -- external_dependencies field must be defined to preventing luarocks
+    -- autodetecting dependencies and causing build failure when the
+    -- dependencies are not found.
+}
+build_dependencies = {
+    "luarocks-build-hooks >= 0.4.0",
 }
 build = {
-    type = "builtin",
+    type = "hooks",
+    before_build = "$(pkgconfig)",
+    pkgconfig_dependencies = {
+        ["LIBPCRE2-8"] = {
+            header = "pcre2.h",
+            library = "pcre2-8",
+        },
+    },
     modules = {
         ["pcre2"] = {
-            sources = { "src/pcre2.c" },
-            libraries = { "pcre2-8" },
+            sources = {
+                "src/pcre2.c",
+            },
+            libraries = {
+                "$(LIBPCRE2-8_LIB)",
+            },
             incdirs = {
                 "deps/lauxhlib",
-                "$(LIBPCRE2_INCDIR)"
+                "$(LIBPCRE2-8_INCDIR)",
             },
             libdirs = {
-                "$(LIBPCRE2_LIBDIR)"
-            }
+                "$(LIBPCRE2-8_LIBDIR)",
+            },
         },
-    }
+    },
 }


### PR DESCRIPTION
This pull request updates the CI workflow and the rockspec configuration to improve build reliability and testing coverage. The main changes include switching to a custom Docker container for CI jobs, updating the Lua version matrix, and modernizing the rockspec to use build hooks and explicit dependency management.

**CI/CD Workflow Improvements:**

* Updated `.github/workflows/test.yml` to use the `ghcr.io/mah0x211/lua-ci:latest` Docker container for both `luacheck` and `test` jobs, ensuring a consistent and controlled build environment. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L3-L19) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R30-R56)
* Modified the workflow to ignore pushes to markdown and license files, reducing unnecessary CI runs.
* Expanded the test matrix to include LuaJIT (`lj-v2.1:latest`) and changed version strings to match the container tags, improving test coverage.
* Replaced the use of `leafo/gh-actions-lua` and `gh-actions-luarocks` with container-based Lua version switching using `lenv`, simplifying setup steps. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L3-L19) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R30-R56)

**Rockspec Modernization:**

* Updated `rockspecs/pcre2-scm-1.rockspec` to use build hooks (`type = "hooks"`) with `luarocks-build-hooks`, and replaced the deprecated `external_dependencies` with `pkgconfig_dependencies` for more reliable dependency detection.
* Added a `build_dependencies` section for `luarocks-build-hooks` to ensure the necessary build tooling is available.
* Improved the specification of library and include directories by using `$(LIBPCRE2-8_LIB)` and `$(LIBPCRE2-8_INCDIR)`, making builds more portable and robust.